### PR TITLE
Update Readme and Generate UI, startup fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,40 @@
 ## FEMbyGEN
 A FreeCAD module that uses Generative Design to calculate and show structural analysis results
 
-![diseration_poster](https://mightybucket.github.io/pics/masters-dissertation/process2.png)**from Rahul Master Thesis Poster**
-
 ### Background 
-This project was devoloped based on [Rahul](https://github.com/MightyBucket/) Master's thesis and [Ogeday Yavuz](https://github.com/OgedaYY/) Graduation Thesis. 
+This project was devoloped based on [Rahul](https://github.com/MightyBucket/) Master's thesis and [Ogeday Yavuz](https://github.com/OgedaYY/) Graduation Thesis.  
+[František Löffelmann](https://github.com/fandaL)'s [calculix/beso](https://github.com/calculix/beso) topology optimization script was added as a feature recently.  
+The following process image is taken from [Master Thesis Poster of Rahul Jhuree](https://mightybucket.github.io/misc/FYP_poster.pdf):
 
-For more information about Rahul thesis please read the [dissertation](https://mightybucket.github.io/projects/2021/05/31/masters-dissertation.html).
+<img src="https://mightybucket.github.io/pics/masters-dissertation/process1.png" width="668px" alt="Rahul Jhuree's generative design process" />
+
+For more information about Rahul's thesis please view the [dissertation](https://mightybucket.github.io/projects/2021/05/31/masters-dissertation.html).
 
 ### Requirements
-- scipy => 1.0.0
-- [FreeCAD](https://freecadweb.org) => 0.19.0
-
-FEMbyGEN has been tested on FreeCAD 0.20 and scipy 1.10.1
+- scipy => 1.10.1
+- [FreeCAD](https://www.freecad.org) => 0.20.0
 
 ### Installation
-
-Recommended installation is via the FreeCAD [Addon Manager](https://wiki.freecad.org/Std_AddonMgr). 
-
-1. Tools → Addon manager
-2. Find the **FEMbyGEN** addon. Install.
-3. A restart prompt will display. Click Ok to restart FreeCAD.
-5. Once FreeCAD reloads, find the [workbench selection drop down menu](https://wiki.freecad.org/Interface) in the top middle of the window, you should see the option for "**FEMbyGEN**. Selecting this will activate the workbench.
-
-Result: All of the functions will work out of the box.
+Recommended installation of the workbench is via the FreeCAD [Addon Manager](https://wiki.freecad.org/Std_AddonMgr).  
+A restart of FreeCAD is required after installation.
 
 ### Usage
-1. Create a FEM simulation in Freecad by using the classical procedure described within wiki documentation. This file will be your master simulation. 
-2. Open fembygen workbench. First button for initialization. It will create a spreadsheet which name is Parameters. You can open it and write your parameters and number of generations.
-3. Then click the second button to alias parameter names and dimensions. Assign your dimensions by classical spreadsheet definition. Freecad wiki documentation and youtube can illustrate how this is done.
-4. Click the generate button to create new generations. Check the files simply by clicking table in the FreeCAD UI.
-5. Use FEA button to generate FEM simulations of all created generations.
-6. Check all results by clicking results button. Note: open the generated files by clicking table rows of results GUI. In addition, all results will append to the master file, check tree view for that.
+1. Create a FEM simulation in FreeCAD by using the [classical procedure](https://wiki.freecad.org/FEM_Workbench). This file will be your master simulation.
+2. Open FEMbyGEN workbench. Press first toolbar icon for initialization. It will create a spreadsheet which name is `Parameters`. Open it and write your parameters for different generations.
+3. Click the second toolbar icon to automatically alias parameter names and dimensions all at once.
+4. Assign your aliased dimensions to sketch constraints or any other property fields using the [expressions editor](https://wiki.freecad.org/Expressions).
+5. Click the **Generate** toolbar icon and then the `Generate` button to create new generations. Check the generation files by using the provided GUI or simply by clicking its table cell.
+6. Use **FEA Generations** toolbar icon to generate FEM simulations of all created generations.
+7. Check all results by clicking **Show Results** toolbar icon. Note: open the generated files by clicking table rows of results GUI. In addition, all results will append to the master file, check tree view for that.
 
 #### Notes
-The addon will also suggest optimum geometry for boundry conditions. By clicking **Creategeo** button, the ability to choose boundries such as supports, pressures, forces, and the function will create an optimum body.
+The addon can also suggest optimum geometry for boundary conditions.
 
-By clicking the **Topology** button a topology optimization analysis will be executed.
+1. By clicking **Create Geo Generations** toolbar icon, the ability to choose boundaries such as supports, pressures, forces and the function will create an optimum body.
+2. By clicking the **Topology** toolbar icon a topology optimization analysis will be executed.
 
 ### Feedback
-Bug reports are greatly appreciated. Please open a ticket in this repository. Please remember to always add your full [About](https://wiki.freecad.org/About) info when opening a ticket (and make sure you're using the latest version of the addon). Feature requests can also be requested in this repository. Please consider logging into the FreeCAD [forum thread]() dedicated to the FEMbyGEN addon to discuss your ideas with the devs.
+Bug reports are greatly appreciated. Please open a ticket in this repository. Please remember to always add your full [About](https://wiki.freecad.org/About) info when opening a ticket (and make sure you're using the latest version of the addon). Feature requests can also be requested in this repository. Please consider logging into the FreeCAD [forum thread](https://forum.freecad.org/viewtopic.php?t=71905) dedicated to the FEMbyGEN addon to discuss your ideas with the devs.
 
 ### License
 LGPLv2.1 ([LICENSE](LICENSE))

--- a/fembygen/Generate.py
+++ b/fembygen/Generate.py
@@ -5,7 +5,7 @@ import os.path
 import shutil
 from fembygen import Common
 import numpy as np
-import PySide
+from PySide import QtCore, QtGui    # FreeCAD's PySide!
 import multiprocessing.dummy as mp
 from multiprocessing import cpu_count
 from functools import partial
@@ -27,7 +27,7 @@ def makeGenerate():
 
 
 class Generate:
-    """ Finite Element Analysis """
+    """Part generations"""
 
     def __init__(self, obj):
         obj.Proxy = self
@@ -45,10 +45,8 @@ class Generate:
                             "Generated parameter matrix")
             obj.addProperty("App::PropertyPythonObject", "GeneratedParameters", "Base",
                             "Generated parameter matrix")
-            
             obj.addProperty("App::PropertyInteger", "NumberOfCPU", "Base",
                             "Number of CPU's to use ")
-            
             obj.NumberOfCPU = cpu_count()-1
         except:
             pass
@@ -87,47 +85,40 @@ class GeneratePanel():
         self.form = FreeCADGui.PySideUic.loadUi(guiPath)
         self.doc = object.Object.Document
         self.workingDir = os.path.dirname(os.path.normpath(self.doc.FileName))
+        Common.setWorkspace(self.doc, self.workingDir)
 
-        # Data variables for parameter table
-        # (paramNames, parameterValues) = Common.checkGenParameters(self.doc)
-        # self.doc.Generate.ParametersName = paramNames
-        # self.doc.Generate.GeneratedParameters = parameterValues
-        index = self.form.selectDesign.findText(self.doc.Generate.GenerationMethod, PySide.QtCore.Qt.MatchFixedString)
+        index = self.form.selectDesign.findText(
+            self.doc.Generate.GenerationMethod, QtCore.Qt.MatchFixedString)
         if index >= 0:
             self.form.selectDesign.setCurrentIndex(index)
+
         # Check if any generations have been made already, and up to what number
-        close = partial(Common.showGen,"close", self.doc)
-        self.form.selectDesign.currentTextChanged.connect(close)
-        numGens = Common.checkGenerations(self.workingDir)
-        self.resetViewControls(numGens)
-
-        self.form.numGensLabel.setText(f"{numGens} generations produced")
-
-        self.selectedGen = -1
-
-        # Connect the button procedures
-        self.form.generateButton.clicked.connect(self.generateParts)
-        self.form.viewGenButton.clicked.connect(self.viewGeneration)
-        self.form.deleteGensButton.clicked.connect(self.deleteGenerations)
-        self.form.nextGen.clicked.connect(lambda: self.nextG(numGens))
-        self.form.previousGen.clicked.connect(
-            lambda: self.previousG(numGens))
-
-        pix = PySide.QtWidgets.QStyle.SP_FileDialogDetailedView
-        icon = self.form.more.style().standardIcon(pix)
-        self.form.more.setIcon(icon)
-        self.form.more.clicked.connect(self.more)
+        self.resetViewControls()
         self.updateParametersTable()
 
+        self.form.more.setIcon(QtGui.QIcon(':/icons/Std_DlgParameter.svg'))
+        self.form.deleteGensButton.setIcon(QtGui.QIcon(':/icons/edit-delete.svg'))
+
+        # Connect the signal procedures
+        self.form.selectDesign.currentTextChanged.connect(self.designChanged)
+        self.form.more.clicked.connect(self.more)
+        self.form.generateButton.clicked.connect(self.generateParts)
+        self.form.selectGenBox.valueChanged.connect(self.viewGeneration)
+        self.form.nextGen.clicked.connect(self.form.selectGenBox.stepUp)
+        self.form.previousGen.clicked.connect(self.form.selectGenBox.stepDown)
+        self.form.deleteGensButton.clicked.connect(self.deleteGenerations)
+
+    def designChanged(self, text):
+        if text in ["Box Behnken Design", "Central Composite Design", "Latin Hyper Cube Design"]:
+            self.form.more.setEnabled(True)
+        else:
+            self.form.more.setEnabled(False)
+
     def more(self):
-        """I will write here a detailed inputs screens for methods"""
+        """Input screens for methods"""
         path = os.path.join(FreeCAD.getUserAppDataDir(), LOCATION, 'ui')
         method = self.form.selectDesign.currentText()
-        if method == "Full Factorial Design":
-            pass
-        elif method == "Plackett Burman Design":
-            pass
-        elif method == "Box Behnken Design":
+        if method == "Box Behnken Design":
             def save():
                 self.doc.Generate.CenterPoints = int(settings.center.text())
                 settings.close()
@@ -157,10 +148,10 @@ class GeneratePanel():
             settings.show()
             try:
                 settings.center.setText(str(self.doc.Generate.Center))
-                index_alpha = settings.alpha.findText(self.doc.Generate.Alpha, PySide.QtCore.Qt.MatchFixedString)
+                index_alpha = settings.alpha.findText(self.doc.Generate.Alpha, QtCore.Qt.MatchFixedString)
                 if index_alpha >= 0:
                     settings.alpha.setCurrentIndex(index_alpha)
-                index_face = settings.face.findText(self.doc.Generate.Face, PySide.QtCore.Qt.MatchFixedString)
+                index_face = settings.face.findText(self.doc.Generate.Face, QtCore.Qt.MatchFixedString)
                 if index_face >= 0:
                     settings.face.setCurrentIndex(index_face)
             except:
@@ -196,7 +187,7 @@ class GeneratePanel():
             settings.show()
             try:
                 settings.samples.setText(str(self.doc.Generate.Samples))
-                index = settings.criterion.findText(self.doc.Generate.Criterion, PySide.QtCore.Qt.MatchFixedString)
+                index = settings.criterion.findText(self.doc.Generate.Criterion, QtCore.Qt.MatchFixedString)
                 if index >= 0:
                     settings.criterion.setCurrentIndex(index)
                 settings.iterations.setText(str(self.doc.Generate.Iterations))
@@ -220,9 +211,7 @@ class GeneratePanel():
             except:
                 pass
             settings.show()
-            settings.save.clicked.connect(save)            
-        elif method == "Taguchi Optimization Design":
-            pass
+            settings.save.clicked.connect(save)
 
     def meshing(self, mesh, type):
         # Remeshing new generation
@@ -237,16 +226,16 @@ class GeneratePanel():
 
     def copy_mesh(self, numgenerations, i):
         docPath = os.path.normpath(self.doc.FileName)
-        directory = os.path.join(self.workingDir, f"Gen{i+1}")
-        filename = f"Gen{i+1}.FCStd"
-        filePath = os.path.join(directory, filename)
+        name = f"Gen{i+1}"
+        directory = os.path.join(self.workingDir, name)
+        filePath = os.path.join(directory, name+".FCStd")
+        
         # Regenerate the part and save generation as FreeCAD doc
         try:
             os.mkdir(directory)
         except:
-            FreeCAD.Console.PrintError(f"Please delete earlier generations folders...\n")
+            FreeCAD.Console.PrintWarning(f"Keeping existing {name}\n")
             return
-
         shutil.copy(docPath, filePath)
         shutil.copy(filePath, filePath+".backup")
 
@@ -287,7 +276,7 @@ class GeneratePanel():
                     if lc > 1:
                         for femobj in obj.Group:
                             # delete old mesh of second or later analysis
-                            if femobj.TypeId == 'Fem::FemMeshObjectPython' or femobj.TypeId == 'Fem::FemMeshShapeNetgenObject':
+                            if femobj.TypeId in ['Fem::FemMeshObjectPython', 'Fem::FemMeshShapeNetgenObject']:
                                 doc.removeObject(femobj.Name)
 
                         # copying same mesh to other loadcases
@@ -298,7 +287,7 @@ class GeneratePanel():
 
         doc.recompute()
         doc.save()
-        FreeCAD.closeDocument(filename[:-6])
+        FreeCAD.closeDocument(name)
 
     def generateParts(self):
         master = self.doc
@@ -327,23 +316,27 @@ class GeneratePanel():
             numberofgen = int(master.Parameters.get(f'E{i+2}'))
             param.append(np.linspace(mins, maxs, numberofgen))
 
-        self.form.progressBar.setStyleSheet(
-            'QProgressBar {text-align: center; } QProgressBar::chunk {background-color: #009688;}')
         # Combination of all parameters
         selectedModule = self.form.selectDesign.currentText()
         self.doc.Generate.GenerationMethod = selectedModule
 
         numgenerations = self.design(selectedModule, param, numberofgen)
+        iterationnumber = len(numgenerations)
 
-        numGens = Common.checkGenerations(self.workingDir)  # delete earlier generations files before
-        if numGens > 0:
+        # delete earlier generations files before
+        if Common.checkGenerations() > 0:
             self.deleteGenerations()
 
+        # Progress bars
+        progress_bar = FreeCAD.Base.ProgressIndicator()    # FreeCAD's progress bar
+        progress_bar.start('Generate parts ...', iterationnumber)
+        self.form.progressBar.setValue(1)
+
         func = partial(self.copy_mesh, numgenerations)
-        iterationnumber = len(numgenerations)
         p = mp.Pool(self.doc.Generate.NumberOfCPU)
         for i, _ in enumerate(p.imap_unordered(func, range(iterationnumber))):
             # Update progress bar
+            progress_bar.next()
             progress = ((i+1)/iterationnumber) * 100
             self.form.progressBar.setValue(progress)
         p.close()
@@ -353,147 +346,106 @@ class GeneratePanel():
         FreeCAD.setActiveDocument(master.Name)
         master.Generate.GeneratedParameters = numgenerations
         master.Generate.ParametersName = paramNames
-        self.updateParametersTable()
 
         # Update number of generations produced in window
-        numGens = Common.checkGenerations(self.workingDir)
-        self.form.numGensLabel.setText(
-            str(numGens) + " generations produced")
-        self.resetViewControls(numGens)
+        self.resetViewControls()
         self.updateParametersTable()
+        progress_bar.stop()
+
         master.save()  # too store generated values in generate object
         FreeCAD.Console.PrintMessage("Generation done successfully!\n")
+        Common.openGen(1)
 
     def deleteGenerations(self):
-        qm = PySide.QtWidgets.QMessageBox
-        ret = qm.question(None, '', "Are you sure to delete all the earlier generation files?", qm.Yes | qm.No)
+        qm = QtGui.QMessageBox
+        ret = qm.question(None, '',
+                          "Are you sure to delete all the earlier generation files?",
+                          qm.Yes | qm.No)
+        if ret == qm.No:
+            FreeCAD.Console.PrintMessage("Nothing Deleted\n")
+        else:
+            Common.closeGen(0)    # close all generations
 
-        if ret == qm.Yes:
-
-            FreeCAD.Console.PrintMessage("Deleting...\n")
-
+            # Delete analysis directories
             numGens = Common.checkGenerations(self.workingDir)
             for i in range(1, numGens+1):
-                # Delete analysis directories
                 directory = os.path.join(self.workingDir, f"Gen{i}")
                 try:
                     shutil.rmtree(directory)
-                    FreeCAD.Console.PrintMessage(directory + " deleted\n")
                 except FileNotFoundError:
-                    FreeCAD.Console.PrintError("INFO: Generation " + str(i) +
-                                               " analysis data not found\n")
-                    pass
-                except:
+                    FreeCAD.Console.PrintError(f"Generation {i} analysis data not found\n")
+                except Exception:
                     FreeCAD.Console.PrintError(
-                        "Error while trying to delete analysis folder for generation\n " + str(i))
+                        f"Error while trying to delete analysis folder for generation {i}\n")
+                else:
+                    FreeCAD.Console.PrintMessage(directory + " deleted\n")
 
             # Delete if earlier generative objects exist
-            try:
-                for l in self.doc.GenerativeDesign.Group:
-                    if l.Name == "Parameters" or l.Name == "Generate":
-                        pass
-                    elif l.Name == "Results":
-                        Common.purge_results(self.doc)
-                    else:
-                        self.doc.removeObject(l.Name)
-            except:
-                pass
+            for l in self.doc.GenerativeDesign.Group:
+                if l.Name == "Parameters" or l.Name == "Generate":
+                    pass
+                elif l.Name == "Results":
+                    Common.purge_results(self.doc)
+                else:
+                    self.doc.removeObject(l.Name)
 
             self.doc.Generate.GeneratedParameters = None
-            # refreshing the table
-            self.resetViewControls(numGens)
+            self.resetViewControls()
             self.updateParametersTable()
             FreeCAD.setActiveDocument(self.doc.Name)
-        else:
-            qm.information(None, '', "Nothing Changed")
-            FreeCAD.Console.PrintMessage("Nothing Deleted\n")
 
-    def nextG(self, numGens):
-        index = self.form.selectGenBox.currentIndex()
-        if index >= numGens-1:
-            index = -1
-        self.form.selectGenBox.setCurrentIndex(index+1)
-        self.viewGeneration()
+    def viewGeneration(self, value):
+        keep = self.form.checkBoxKeep.isChecked()
+        Common.viewGen(value, keep)
+        self.form.parametersTable.selectRow(value-1)
 
-    def previousG(self, numGens):
-        index = self.form.selectGenBox.currentIndex()
-        if index <= 0:
-            index = numGens
-        self.form.selectGenBox.setCurrentIndex(index-1)
-        self.viewGeneration()
+    def resetViewControls(self):
+        numGens = Common.checkGenerations()
 
-    def viewGeneration(self):
-        # Close the generation that the user might be viewing previously
-        if self.selectedGen > 0:
-            docName = f"Gen{self.selectedGen}"
-            FreeCAD.closeDocument(docName)
+        enable = True if numGens > 0 else False
+        self.form.selectGenBox.setEnabled(enable)
+        self.form.nextGen.setEnabled(enable)
+        self.form.previousGen.setEnabled(enable)
 
-        # Find which generation is selected in the combo box
-        self.selectedGen = self.form.selectGenBox.currentText()
-        self.selectedGen = int(str(self.selectedGen).split()[-1])
-
-        # Open the generation
-        docName = f"Gen{self.selectedGen}"
-        docPath = os.path.join(self.workingDir, docName, docName+".FCStd")
-        FreeCAD.open(docPath)
-        # FreeCAD.setActiveDocument(docName)
-
-    def resetViewControls(self, numGens):
-        comboBoxItems = []
-
-        if numGens > 0:
-            self.form.viewGenButton.setEnabled(True)
-            self.form.selectGenBox.setEnabled(True)
-            self.form.nextGen.setEnabled(True)
-            self.form.previousGen.setEnabled(True)
-
-            for i in range(1, numGens+1):
-                comboBoxItems.append("Generation " + str(i))
-
-            self.form.selectGenBox.clear()
-            self.form.selectGenBox.addItems(comboBoxItems)
-        else:
-            self.form.viewGenButton.setEnabled(False)
-            self.form.selectGenBox.setEnabled(False)
-            self.form.nextGen.setEnabled(False)
-            self.form.previousGen.setEnabled(False)
-            self.form.selectGenBox.clear()
+        self.form.numGensLabel.setText(f"{numGens} generations produced")
+        self.form.selectGenBox.setRange(1, numGens)
 
     def updateParametersTable(self):
         paramNames = self.doc.Generate.ParametersName
         parameterValues = self.doc.Generate.GeneratedParameters
+        tableWidget = self.form.parametersTable
+        
         if parameterValues == None:
-            paramNames = [""]
-            parameterValues = []
-        # Insert generation number column into table
+            tableWidget.setEnabled(False)
+            return
 
-        paramNames.insert(0, "Gen")
-        table = []
-        for i in range(1, len(parameterValues)+1):
-            table.append([i]+list(parameterValues[i-1]))
+        tableWidget.setEnabled(True)
+        tableWidget.setColumnCount(len(paramNames))
+        tableWidget.setRowCount(len(parameterValues))
+        tableWidget.setHorizontalHeaderLabels(paramNames)
+        tableWidget.horizontalHeader().setResizeMode(QtGui.QHeaderView.ResizeToContents)
 
-        tableModel = Common.GenTableModel(
-            self.form, table, paramNames)
-        tableModel.layoutChanged.emit()
-        self.form.parametersTable.setModel(tableModel)
-        self.form.parametersTable.horizontalHeader().setResizeMode(
-            PySide.QtWidgets.QHeaderView.ResizeToContents)
-        self.form.parametersTable.clicked.connect(partial(
-            Common.showGen, self.form.parametersTable, self.doc))
-        self.form.parametersTable.setMinimumHeight(22+len(parameterValues)*30)
-        self.form.parametersTable.setMaximumHeight(22+len(parameterValues)*30)
+        for col in range(tableWidget.columnCount()):
+            for row in range(tableWidget.rowCount()):
+                item = QtGui.QTableWidgetItem(str(parameterValues[row][col]))
+                tableWidget.setItem(row, col, item)
+        if Common.checkGenerations() > 0:
+            tableWidget.itemClicked.connect(
+                lambda item: self.form.selectGenBox.setValue(item.row()+1))
 
     def accept(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.resetEdit()
-        doc.Document.recompute()
-        # closes the gen file If a generated file opened to check before
-        Common.showGen("close", self.doc, None)
+        """Qt convenience function: Ok pressed"""
+        if not self.form.checkBoxKeep.isChecked():
+            Common.closeGen(0)    # close all generations
+        guiDoc = FreeCADGui.getDocument(self.doc)
+        guiDoc.resetEdit()    # close dialog
+        self.doc.recompute()
 
     def reject(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.resetEdit()
-        # Common.showGen("close", self.doc, None)   # closes the gen file If a generated file opened to check before
+        """Qt convenience function: Cancel pressed"""
+        Common.closeGen(0)    # close all generations
+        guiDoc = FreeCADGui.getDocument(self.doc)
+        guiDoc.resetEdit()    # close dialog
 
     def design(self, method, parameters, numberofgen):
         from fembygen.design import Design, Taguchi

--- a/fembygen/createGeo.py
+++ b/fembygen/createGeo.py
@@ -3,7 +3,7 @@ import FreeCADGui
 import os
 import ObjectsFem
 from fembygen import Topology
-from PySide import QtGui,QtCore,QtWidgets
+from PySide import QtGui, QtCore
 import shutil
 
 
@@ -131,7 +131,7 @@ class CreateGeoPanel:
             FreeCAD.Console.PrintError("Please Select Body\n")
             return
         for obj in selection:
-            item = QtWidgets.QListWidgetItem(obj.Label)
+            item = QtGui.QListWidgetItem(obj.Label)
             self.form.preserve_bodies.addItem(item)
             font = item.font()
             font_size = font.pointSize()
@@ -172,7 +172,7 @@ class CreateGeoPanel:
             FreeCAD.Console.PrintError("Please Select Body\n")
             return
         for obj in selection:
-            item = QtWidgets.QListWidgetItem(obj.Label)
+            item = QtGui.QListWidgetItem(obj.Label)
             self.form.obstacle_bodies.addItem(item)
             font = item.font()
             font_size = font.pointSize()

--- a/fembygen/ui/Generate.ui
+++ b/fembygen/ui/Generate.ui
@@ -29,6 +29,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QComboBox" name="selectDesign">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <item>
         <property name="text">
          <string>Full Factorial Design</string>
@@ -63,41 +69,19 @@
      </item>
      <item>
       <widget class="QPushButton" name="more">
-       <property name="minimumSize">
-        <size>
-         <width>30</width>
-         <height>0</height>
-        </size>
+       <property name="enabled">
+        <bool>false</bool>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>30</width>
-         <height>16777215</height>
-        </size>
+       <property name="toolTip">
+        <string>Parameter settings</string>
        </property>
        <property name="text">
         <string/>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>:/svg/FEMbyGEN/fembygen/icons/setting.svg</normaloff>:/svg/FEMbyGEN/fembygen/icons/setting.svg</iconset>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="generateButton">
-       <property name="minimumSize">
-        <size>
-         <width>90</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>120</width>
-         <height>16777215</height>
-        </size>
-       </property>
        <property name="text">
         <string>Generate</string>
        </property>
@@ -116,23 +100,27 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="labelView">
+     <property name="text">
+      <string>Click arrows or table row to view Gen:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="previousGen">
        <property name="enabled">
         <bool>false</bool>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>25</width>
-         <height>0</height>
-        </size>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="maximumSize">
-        <size>
-         <width>25</width>
-         <height>16777215</height>
-        </size>
+       <property name="toolTip">
+        <string>View previous</string>
        </property>
        <property name="text">
         <string>&lt;</string>
@@ -140,9 +128,31 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="selectGenBox">
+      <widget class="QSpinBox" name="selectGenBox">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="prefix">
+        <string>Gen </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBoxKeep">
+       <property name="toolTip">
+        <string>Reduces the time for reloading</string>
+       </property>
+       <property name="text">
+        <string>keep open</string>
        </property>
       </widget>
      </item>
@@ -151,68 +161,41 @@
        <property name="enabled">
         <bool>false</bool>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>25</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>25</width>
-         <height>16777215</height>
-        </size>
+       <property name="toolTip">
+        <string>View next</string>
        </property>
        <property name="text">
         <string>&gt;</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="viewGenButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>60</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>80</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>View</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
-    <widget class="QTableView" name="parametersTable">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>200</height>
-      </size>
+    <widget class="QTableWidget" name="parametersTable">
+     <property name="toolTip">
+      <string>Select view</string>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QPushButton" name="deleteGensButton">
      <property name="text">
-      <string>Delete Generations</string>
+      <string>Delete all generations</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../../aa.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
- Fixed startup error in FreeCAD 0.20
Error: "cannot import name 'QtWidgets' from 'PySide'"
Solution: PySide2.QtWidgets classes are placed in the PySide.QtGui namespace (https://wiki.freecad.org/PySide)
- Updated Readme
  - Flow chart changed for readability on dark background
  - Added links
  - Clarifications in usage
- Rework of Generate UI
  - Improved switching through the generations
  - FreeCAD progress bar added
  - Code simplifications and responsive design
  - More robust usage of file paths